### PR TITLE
[dv/lc_ctrl] Fix when RndCnstRawUnlockTokenHashed is not 0

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -13,6 +13,7 @@ interface lc_ctrl_if(input clk, input rst_n);
   logic prog_err; // TODO: remove once push-pull can constrain data
   otp_ctrl_pkg::otp_lc_data_t     otp_i;
   otp_ctrl_part_pkg::otp_hw_cfg_t otp_hw_cfg_i;
+  lc_ctrl_pkg::lc_token_t hashed_token;
 
   lc_ctrl_pkg::lc_tx_t lc_dft_en_o;
   lc_ctrl_pkg::lc_tx_t lc_nvm_debug_en_o;
@@ -54,6 +55,7 @@ interface lc_ctrl_if(input clk, input rst_n);
     clk_byp_ack_i = clk_byp_ack;
     flash_rma_ack_i = flash_rma_ack;
     prog_err = 0;
+    hashed_token = '0;
   endtask
 
   task automatic set_clk_byp_ack(lc_ctrl_pkg::lc_tx_t val);
@@ -64,4 +66,7 @@ interface lc_ctrl_if(input clk, input rst_n);
     flash_rma_ack_i = val;
   endtask
 
+  task automatic set_hashed_token(lc_ctrl_pkg::lc_token_t val);
+    hashed_token = val;
+  endtask
 endinterface

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -42,6 +42,10 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
         randomize_next_lc_state(dec_lc_state(lc_state));
         `uvm_info(`gfn, $sformatf("next_LC_state is %0s, input token is %0h", next_lc_state.name,
                                   token_val), UVM_DEBUG)
+        if (lc_state == LcStRaw && next_lc_state inside {DecLcStTestUnlocked0,
+            DecLcStTestUnlocked1, DecLcStTestUnlocked2, DecLcStTestUnlocked3}) begin
+          cfg.lc_ctrl_vif.set_hashed_token(lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed);
+        end
         sw_transition_req(next_lc_state, token_val, trans_success);
       end else begin
         // wait at least two clks for scb to finish checking lc outputs

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -43,7 +43,7 @@ module tb;
   assign otp_prog_rsp.ack = otp_prog_if.ack;
   assign otp_token_rsp.ack = otp_token_if.ack;
   // TODO: temp constraint to 0 because it has to equal to otp_lc_data_i tokens
-  assign otp_token_rsp.hashed_token = 0;
+  assign otp_token_rsp.hashed_token = lc_ctrl_if.hashed_token;
 
   // dut
   lc_ctrl dut (


### PR DESCRIPTION
In current lc_ctrl smoke test, we assume all the tokens to be 0, but
with otp_ctrl update, we are randomize the `RndCnstRawUnlockTokenHashed`
constant. This commit fix it by driving correct hashed token from OTP
when `*TestUnlock*` states are requested.

Signed-off-by: Cindy Chen <chencindy@google.com>