### PR TITLE
[dv/alert_init] Remove ping diff pair in init

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -187,12 +187,10 @@ class alert_receiver_driver extends alert_esc_base_driver;
     `DV_SPINWAIT_EXIT(
         // Drive alert init signal integrity error handshake.
         repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
-        cfg.vif.alert_rx_int.ping_n <= 1'b0;
-        wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
         cfg.vif.alert_rx_int.ack_n <= 1'b0;
+        wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
         repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
         cfg.vif.alert_rx_int.ack_n  <= 1'b1;
-        cfg.vif.alert_rx_int.ping_n <= 1'b1;
         wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);
         under_reset = 0;,
         @(negedge cfg.vif.rst_n);)

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -242,9 +242,9 @@ class alert_sender_driver extends alert_esc_base_driver;
     fork begin
       fork
         begin
-          wait (cfg.vif.alert_rx.ping_p == cfg.vif.alert_rx.ping_n);
+          wait (cfg.vif.alert_rx.ack_p == cfg.vif.alert_rx.ack_n);
           cfg.vif.alert_tx_int.alert_n <= 1'b0;
-          wait (cfg.vif.alert_rx.ping_p != cfg.vif.alert_rx.ping_n);
+          wait (cfg.vif.alert_rx.ack_p != cfg.vif.alert_rx.ack_n);
           cfg.vif.alert_tx_int.alert_n <= 1'b1;
           under_reset = 0;
         end


### PR DESCRIPTION
This PR removes setting ping diff pair to all 0s in alert init to avoid
collision with ping request.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>